### PR TITLE
Add r-universe URL to allow osutils to show in opensafely-core.r-universe.dev search

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Description: Contains functions that are often needed when using the
     OpenSAFELY platform <https://www.opensafely.org/>, such as redaction
     and low-memory processing.
 License: MIT + file LICENSE
-URL: https://github.com/wjchulme/osutils
+URL: https://github.com/wjchulme/osutils,
+    https://opensafely-core.r-universe.dev/osutils
 BugReports: https://github.com/wjchulme/osutils/issues/
 Imports: 
     broom,


### PR DESCRIPTION
Merging this will make the annoying yellow box go away.

<https://opensafely-core.r-universe.dev/osutils>

![CleanShot 2024-12-11 at 16 12 22@2x](https://github.com/user-attachments/assets/08d1ae0a-8dfa-44bd-9737-3233531cd224)
